### PR TITLE
Fix task-related noise generation in simVOLfmri

### DIFF
--- a/R/simVOLfmri.R
+++ b/R/simVOLfmri.R
@@ -124,7 +124,7 @@ function(design=list(), image=list(), base=0, dim, nscan=NULL, TR=NULL, SNR=NULL
     n <- physnoise(dim=dim, sigma=sigma, nscan=nscan, TR=TR, freq.heart=freq.heart, freq.resp=freq.resp, verbose=verbose, template=template)
   }
   if(noise=="task-related"){
-    n <- tasknoise(act.image=act, sigma=sigma, type=type, vee=vee)
+    n <- tasknoise(act.image=act.image, sigma=sigma, type=type, vee=vee)
   }
   if(noise=="spatial"){
     n <- spatialnoise(dim=dim, sigma=sigma, nscan=nscan, method=spat, type=type, rho=rho.spat, FWHM=FWHM, gamma.shape=gamma.shape, gamma.rate=gamma.rate, vee=vee, template=template, verbose=verbose)


### PR DESCRIPTION
In case you're collecting fixes, here's one I made a while back. I figure that, given that the package is unmaintained, a single place to collect the fixes might not be a bad idea.

Commit text follows.

----

Task-related noise should have no effect on inactive voxels.

Generate a random set of active voxels:

```R
  pattern <- array(runif(100), dim=c(10, 10, 1)) <= 0.2
```

Simulate a single pulse, HRF peaking at volume 3:
```R
  coords <- which(pattern, arr.ind=TRUE)
  clist <- list()
  for (i in 1:length(coords[,1])) {
      clist[[i]] <- t(matrix(coords[i,]))
  }
  image <- simprepSpatial(sum(map), clist, form='manual', radius=1)
  design <- simprepTemporal(10, onsets=0, durations=0.5, TR=2.5,
                            effectsize=10)
  vol <- simVOLfmri(design=design, image=image, nscan=4, TR=2.5,
                    noise='task-related', SNR=2, dim=c(10, 10, 1))
```

Compare images:
```R
  image(pattern[,,1])
  image(vol[,,1,3])
```